### PR TITLE
Remove use of ioutil package

### DIFF
--- a/google-io-2014/handler_main/handler_main.go
+++ b/google-io-2014/handler_main/handler_main.go
@@ -1,13 +1,13 @@
 // START OMIT
 package main
+
 //OMIT
-import _ "github.com/sourcegraph/talks/google-io-2014/javascript" // HL
+import (
+	_ "github.com/sourcegraph/talks/google-io-2014/javascript"
+	"github.com/sourcegraph/talks/google-io-2014/lang"
+) // HL
 
 // END OMIT
-
-import (
-	"github.com/sourcegraph/talks/google-io-2014/lang"
-)
 
 func main() {
 	lang.PrintHandlers()

--- a/google-io-2014/javascript/js_handler.go
+++ b/google-io-2014/javascript/js_handler.go
@@ -1,7 +1,6 @@
 package javascript
 
 import (
-	"io/ioutil"
 	"log"
 	"regexp"
 
@@ -15,7 +14,7 @@ type JSAnalyzer struct{}
 var jsdef = regexp.MustCompile(`(var|function) (\w+)`)
 
 func (_ JSAnalyzer) Analyze(file string) ([]*lang.Def, []*lang.Ref, error) { // HL
-	src, err := ioutil.ReadFile(file)
+	src, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)